### PR TITLE
Stop depending on stderr to detect errors

### DIFF
--- a/src/lib/init.luau
+++ b/src/lib/init.luau
@@ -83,7 +83,7 @@ local function runScript(script: Script<any>, cwd: string?)
 			cwd = cwd,
 		})
 
-		if not result.ok or #result.stderr > 0 then -- No idea if this is actually accurate for all cli's
+		if not result.ok then -- No idea if this is actually accurate for all cli's
 			error(`{stdio.color("red")}Error while running command: {str}\n{stdio.color("reset")}{result.stderr}`, 0)
 		end
 	end


### PR DESCRIPTION
Stop depending on stderr to detect errors from script processes.

stderr isn't always guaranteed to be an error. It can sometimes be a warning, or it can simply be a logging message unrelated to an error. (TMI: The popular Rust library env_logger writes to stderr by default.)